### PR TITLE
feat: add multi-container and init container support for WIF injection

### DIFF
--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestInjectWorkloadIdentityConfig(t *testing.T) {
 	// Set required environment variables for testing
-	os.Setenv("WORKLOAD_IDENTITY_PROVIDER", "projects/123456789/locations/global/workloadIdentityPools/test-pool/providers/test-provider")
+	require.NoError(t, os.Setenv("WORKLOAD_IDENTITY_PROVIDER", "projects/123456789/locations/global/workloadIdentityPools/test-pool/providers/test-provider"))
 
 	config := &WIFConfig{}
 
@@ -361,6 +361,521 @@ func TestInjectWorkloadIdentityConfig(t *testing.T) {
 		assert.Equal(t, 1, credsCount, "Should only have one GOOGLE_APPLICATION_CREDENTIALS env var - injection was skipped")
 	})
 
+	t.Run("should inject WIF into all containers when no annotation specified", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multi-container-pod",
+				Namespace: "default",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "app-container",
+						Image: "nginx",
+					},
+					{
+						Name:  "sidecar-container",
+						Image: "busybox",
+					},
+					{
+						Name:  "another-container",
+						Image: "redis",
+					},
+				},
+			},
+		}
+
+		injectWorkloadIdentityConfig(nil, pod, config)
+
+		// Volumes should be added once at pod level
+		assert.Len(t, pod.Spec.Volumes, 2, "Expected two volumes (token and credentials)")
+
+		// All containers should get volume mounts and env vars
+		for i, container := range pod.Spec.Containers {
+			assert.Len(t, container.VolumeMounts, 2, "Container %d should have two volume mounts", i)
+			assert.Len(t, container.Env, 1, "Container %d should have one env var", i)
+			assert.Equal(t, "GOOGLE_APPLICATION_CREDENTIALS", container.Env[0].Name, "Container %d should have correct env var", i)
+		}
+	})
+
+	t.Run("should inject WIF only into specified containers", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multi-container-pod",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"workload-identity.io/inject-container-names": "app-container,another-container",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "app-container",
+						Image: "nginx",
+					},
+					{
+						Name:  "sidecar-container",
+						Image: "busybox",
+					},
+					{
+						Name:  "another-container",
+						Image: "redis",
+					},
+				},
+			},
+		}
+
+		injectWorkloadIdentityConfig(nil, pod, config)
+
+		// Volumes should be added once at pod level
+		assert.Len(t, pod.Spec.Volumes, 2, "Expected two volumes (token and credentials)")
+
+		// Check first container (should be injected)
+		assert.Len(t, pod.Spec.Containers[0].VolumeMounts, 2, "First container should have volume mounts")
+		assert.Len(t, pod.Spec.Containers[0].Env, 1, "First container should have env var")
+		assert.Equal(t, "GOOGLE_APPLICATION_CREDENTIALS", pod.Spec.Containers[0].Env[0].Name)
+
+		// Check second container (should not be injected)
+		assert.Len(t, pod.Spec.Containers[1].VolumeMounts, 0, "Second container should have no volume mounts")
+		assert.Len(t, pod.Spec.Containers[1].Env, 0, "Second container should have no env vars")
+
+		// Check third container (should be injected)
+		assert.Len(t, pod.Spec.Containers[2].VolumeMounts, 2, "Third container should have volume mounts")
+		assert.Len(t, pod.Spec.Containers[2].Env, 1, "Third container should have env var")
+		assert.Equal(t, "GOOGLE_APPLICATION_CREDENTIALS", pod.Spec.Containers[2].Env[0].Name)
+	})
+
+	t.Run("should handle whitespace in container names annotation", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multi-container-pod",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"workload-identity.io/inject-container-names": " app-container , sidecar-container , ",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "app-container",
+						Image: "nginx",
+					},
+					{
+						Name:  "sidecar-container",
+						Image: "busybox",
+					},
+					{
+						Name:  "ignored-container",
+						Image: "redis",
+					},
+				},
+			},
+		}
+
+		injectWorkloadIdentityConfig(nil, pod, config)
+
+		// Check first container (should be injected - trimmed whitespace)
+		assert.Len(t, pod.Spec.Containers[0].VolumeMounts, 2, "First container should have volume mounts")
+		assert.Len(t, pod.Spec.Containers[0].Env, 1, "First container should have env var")
+
+		// Check second container (should be injected - trimmed whitespace)
+		assert.Len(t, pod.Spec.Containers[1].VolumeMounts, 2, "Second container should have volume mounts")
+		assert.Len(t, pod.Spec.Containers[1].Env, 1, "Second container should have env var")
+
+		// Check third container (should not be injected)
+		assert.Len(t, pod.Spec.Containers[2].VolumeMounts, 0, "Third container should have no volume mounts")
+		assert.Len(t, pod.Spec.Containers[2].Env, 0, "Third container should have no env vars")
+	})
+
+	t.Run("should handle empty container names annotation", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multi-container-pod",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"workload-identity.io/inject-container-names": "",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "app-container",
+						Image: "nginx",
+					},
+					{
+						Name:  "sidecar-container",
+						Image: "busybox",
+					},
+				},
+			},
+		}
+
+		injectWorkloadIdentityConfig(nil, pod, config)
+
+		// Empty annotation should result in injection into all containers
+		assert.Len(t, pod.Spec.Containers[0].VolumeMounts, 2, "First container should have volume mounts")
+		assert.Len(t, pod.Spec.Containers[0].Env, 1, "First container should have env var")
+		assert.Len(t, pod.Spec.Containers[1].VolumeMounts, 2, "Second container should have volume mounts")
+		assert.Len(t, pod.Spec.Containers[1].Env, 1, "Second container should have env var")
+	})
+
+	t.Run("should handle non-existent container names in annotation", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multi-container-pod",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"workload-identity.io/inject-container-names": "app-container,non-existent-container",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "app-container",
+						Image: "nginx",
+					},
+					{
+						Name:  "sidecar-container",
+						Image: "busybox",
+					},
+				},
+			},
+		}
+
+		injectWorkloadIdentityConfig(nil, pod, config)
+
+		// Only the existing container should be injected
+		assert.Len(t, pod.Spec.Containers[0].VolumeMounts, 2, "First container should have volume mounts")
+		assert.Len(t, pod.Spec.Containers[0].Env, 1, "First container should have env var")
+		assert.Len(t, pod.Spec.Containers[1].VolumeMounts, 0, "Second container should have no volume mounts")
+		assert.Len(t, pod.Spec.Containers[1].Env, 0, "Second container should have no env vars")
+	})
+
+	t.Run("should inject only single container when specified", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multi-container-pod",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"workload-identity.io/inject-container-names": "sidecar-container",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "app-container",
+						Image: "nginx",
+					},
+					{
+						Name:  "sidecar-container",
+						Image: "busybox",
+					},
+				},
+			},
+		}
+
+		injectWorkloadIdentityConfig(nil, pod, config)
+
+		// Volumes should still be at pod level
+		assert.Len(t, pod.Spec.Volumes, 2, "Expected two volumes (token and credentials)")
+
+		// Only second container should be injected
+		assert.Len(t, pod.Spec.Containers[0].VolumeMounts, 0, "First container should have no volume mounts")
+		assert.Len(t, pod.Spec.Containers[0].Env, 0, "First container should have no env vars")
+		assert.Len(t, pod.Spec.Containers[1].VolumeMounts, 2, "Second container should have volume mounts")
+		assert.Len(t, pod.Spec.Containers[1].Env, 1, "Second container should have env var")
+	})
+
+	t.Run("should inject WIF into init containers when specified", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-with-init-containers",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"workload-identity.io/inject-container-names": "init-setup,app-container",
+				},
+			},
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:    "init-setup",
+						Image:   "alpine",
+						Command: []string{"sh", "-c", "echo setting up"},
+					},
+					{
+						Name:    "init-db-migrate",
+						Image:   "migrate/migrate",
+						Command: []string{"migrate", "up"},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:  "app-container",
+						Image: "nginx",
+					},
+					{
+						Name:  "sidecar-container",
+						Image: "busybox",
+					},
+				},
+			},
+		}
+
+		injectWorkloadIdentityConfig(nil, pod, config)
+
+		// Volumes should be added once at pod level
+		assert.Len(t, pod.Spec.Volumes, 2, "Expected two volumes (token and credentials)")
+
+		// Check init containers - only first should be injected
+		assert.Len(t, pod.Spec.InitContainers[0].VolumeMounts, 2, "First init container should have volume mounts")
+		assert.Len(t, pod.Spec.InitContainers[0].Env, 1, "First init container should have env var")
+		assert.Equal(t, "GOOGLE_APPLICATION_CREDENTIALS", pod.Spec.InitContainers[0].Env[0].Name)
+
+		assert.Len(t, pod.Spec.InitContainers[1].VolumeMounts, 0, "Second init container should have no volume mounts")
+		assert.Len(t, pod.Spec.InitContainers[1].Env, 0, "Second init container should have no env vars")
+
+		// Check regular containers - only first should be injected
+		assert.Len(t, pod.Spec.Containers[0].VolumeMounts, 2, "First container should have volume mounts")
+		assert.Len(t, pod.Spec.Containers[0].Env, 1, "First container should have env var")
+		assert.Equal(t, "GOOGLE_APPLICATION_CREDENTIALS", pod.Spec.Containers[0].Env[0].Name)
+
+		assert.Len(t, pod.Spec.Containers[1].VolumeMounts, 0, "Second container should have no volume mounts")
+		assert.Len(t, pod.Spec.Containers[1].Env, 0, "Second container should have no env vars")
+	})
+
+	t.Run("should inject WIF into all containers including init containers when no annotation", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-with-all-containers",
+				Namespace: "default",
+			},
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:    "init-secrets",
+						Image:   "vault:1.12",
+						Command: []string{"vault", "kv", "get"},
+					},
+					{
+						Name:    "init-config",
+						Image:   "busybox",
+						Command: []string{"sh", "-c", "echo configuring"},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:  "app-container",
+						Image: "nginx",
+					},
+					{
+						Name:  "monitoring-container",
+						Image: "prometheus/node-exporter",
+					},
+				},
+			},
+		}
+
+		injectWorkloadIdentityConfig(nil, pod, config)
+
+		// Volumes should be added once at pod level
+		assert.Len(t, pod.Spec.Volumes, 2, "Expected two volumes (token and credentials)")
+
+		// All init containers should get volume mounts and env vars
+		for i, container := range pod.Spec.InitContainers {
+			assert.Len(t, container.VolumeMounts, 2, "Init container %d should have two volume mounts", i)
+			assert.Len(t, container.Env, 1, "Init container %d should have one env var", i)
+			assert.Equal(t, "GOOGLE_APPLICATION_CREDENTIALS", container.Env[0].Name, "Init container %d should have correct env var", i)
+		}
+
+		// All regular containers should get volume mounts and env vars
+		for i, container := range pod.Spec.Containers {
+			assert.Len(t, container.VolumeMounts, 2, "Container %d should have two volume mounts", i)
+			assert.Len(t, container.Env, 1, "Container %d should have one env var", i)
+			assert.Equal(t, "GOOGLE_APPLICATION_CREDENTIALS", container.Env[0].Name, "Container %d should have correct env var", i)
+		}
+	})
+
+	t.Run("should inject WIF only into specified init containers", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-with-targeted-init-containers",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"workload-identity.io/inject-container-names": "init-secrets",
+				},
+			},
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:    "init-secrets",
+						Image:   "vault:1.12",
+						Command: []string{"vault", "kv", "get"},
+					},
+					{
+						Name:    "init-local-setup",
+						Image:   "busybox",
+						Command: []string{"sh", "-c", "echo local setup"},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:  "app-container",
+						Image: "nginx",
+					},
+				},
+			},
+		}
+
+		injectWorkloadIdentityConfig(nil, pod, config)
+
+		// Volumes should be added once at pod level
+		assert.Len(t, pod.Spec.Volumes, 2, "Expected two volumes (token and credentials)")
+
+		// Only first init container should be injected
+		assert.Len(t, pod.Spec.InitContainers[0].VolumeMounts, 2, "First init container should have volume mounts")
+		assert.Len(t, pod.Spec.InitContainers[0].Env, 1, "First init container should have env var")
+
+		assert.Len(t, pod.Spec.InitContainers[1].VolumeMounts, 0, "Second init container should have no volume mounts")
+		assert.Len(t, pod.Spec.InitContainers[1].Env, 0, "Second init container should have no env vars")
+
+		// Regular container should not be injected
+		assert.Len(t, pod.Spec.Containers[0].VolumeMounts, 0, "App container should have no volume mounts")
+		assert.Len(t, pod.Spec.Containers[0].Env, 0, "App container should have no env vars")
+	})
+
+}
+
+func TestParseTargetContainerNames(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    []string
+	}{
+		{
+			name:        "no annotations",
+			annotations: nil,
+			expected:    nil,
+		},
+		{
+			name:        "empty annotations",
+			annotations: map[string]string{},
+			expected:    nil,
+		},
+		{
+			name: "annotation not present",
+			annotations: map[string]string{
+				"other-annotation": "value",
+			},
+			expected: nil,
+		},
+		{
+			name: "empty annotation value",
+			annotations: map[string]string{
+				"workload-identity.io/inject-container-names": "",
+			},
+			expected: nil,
+		},
+		{
+			name: "single container",
+			annotations: map[string]string{
+				"workload-identity.io/inject-container-names": "app-container",
+			},
+			expected: []string{"app-container"},
+		},
+		{
+			name: "multiple containers",
+			annotations: map[string]string{
+				"workload-identity.io/inject-container-names": "app-container,sidecar-container,another-container",
+			},
+			expected: []string{"app-container", "sidecar-container", "another-container"},
+		},
+		{
+			name: "containers with whitespace",
+			annotations: map[string]string{
+				"workload-identity.io/inject-container-names": " app-container , sidecar-container , another-container ",
+			},
+			expected: []string{"app-container", "sidecar-container", "another-container"},
+		},
+		{
+			name: "containers with empty entries",
+			annotations: map[string]string{
+				"workload-identity.io/inject-container-names": "app-container,,sidecar-container,",
+			},
+			expected: []string{"app-container", "sidecar-container"},
+		},
+		{
+			name: "only commas and whitespace",
+			annotations: map[string]string{
+				"workload-identity.io/inject-container-names": " , , ",
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+			}
+			result := parseTargetContainerNames(pod)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestShouldInjectIntoContainer(t *testing.T) {
+	tests := []struct {
+		name             string
+		containerName    string
+		targetContainers []string
+		expected         bool
+	}{
+		{
+			name:             "no target containers specified - inject all",
+			containerName:    "app-container",
+			targetContainers: nil,
+			expected:         true,
+		},
+		{
+			name:             "container in target list",
+			containerName:    "app-container",
+			targetContainers: []string{"app-container", "sidecar-container"},
+			expected:         true,
+		},
+		{
+			name:             "container not in target list",
+			containerName:    "ignored-container",
+			targetContainers: []string{"app-container", "sidecar-container"},
+			expected:         false,
+		},
+		{
+			name:             "empty target list - inject none",
+			containerName:    "app-container",
+			targetContainers: []string{},
+			expected:         false,
+		},
+		{
+			name:             "single target container - match",
+			containerName:    "app-container",
+			targetContainers: []string{"app-container"},
+			expected:         true,
+		},
+		{
+			name:             "single target container - no match",
+			containerName:    "sidecar-container",
+			targetContainers: []string{"app-container"},
+			expected:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldInjectIntoContainer(tt.containerName, tt.targetContainers)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }
 
 func TestPotentialPodName(t *testing.T) {
@@ -413,13 +928,13 @@ func TestPotentialPodName(t *testing.T) {
 
 func TestPodWebhookIntegration(t *testing.T) {
 	// Set required environment variables for testing
-	os.Setenv("PROJECT_NUMBER", "123456789")
-	os.Setenv("POOL_ID", "test-pool")
-	os.Setenv("PROVIDER_ID", "test-provider")
+	require.NoError(t, os.Setenv("PROJECT_NUMBER", "123456789"))
+	require.NoError(t, os.Setenv("POOL_ID", "test-pool"))
+	require.NoError(t, os.Setenv("PROVIDER_ID", "test-provider"))
 	defer func() {
-		os.Unsetenv("PROJECT_NUMBER")
-		os.Unsetenv("POOL_ID")
-		os.Unsetenv("PROVIDER_ID")
+		require.NoError(t, os.Unsetenv("PROJECT_NUMBER"))
+		require.NoError(t, os.Unsetenv("POOL_ID"))
+		require.NoError(t, os.Unsetenv("PROVIDER_ID"))
 	}()
 
 	testSA := &corev1.ServiceAccount{
@@ -523,13 +1038,13 @@ func TestPodWebhookIntegration(t *testing.T) {
 // BenchmarkWebhookDefault measures webhook performance
 func BenchmarkWebhookDefault(b *testing.B) {
 	// Set required environment variables for testing
-	os.Setenv("PROJECT_NUMBER", "123456789")
-	os.Setenv("POOL_ID", "test-pool")
-	os.Setenv("PROVIDER_ID", "test-provider")
+	require.NoError(b, os.Setenv("PROJECT_NUMBER", "123456789"))
+	require.NoError(b, os.Setenv("POOL_ID", "test-pool"))
+	require.NoError(b, os.Setenv("PROVIDER_ID", "test-provider"))
 	defer func() {
-		os.Unsetenv("PROJECT_NUMBER")
-		os.Unsetenv("POOL_ID")
-		os.Unsetenv("PROVIDER_ID")
+		require.NoError(b, os.Unsetenv("PROJECT_NUMBER"))
+		require.NoError(b, os.Unsetenv("POOL_ID"))
+		require.NoError(b, os.Unsetenv("PROVIDER_ID"))
 	}()
 
 	// Create test objects
@@ -590,13 +1105,13 @@ func BenchmarkWebhookDefault(b *testing.B) {
 // BenchmarkWebhookDefaultWithConfigMapCreation measures webhook performance including ConfigMap creation
 func BenchmarkWebhookDefaultWithConfigMapCreation(b *testing.B) {
 	// Set required environment variables for testing
-	os.Setenv("PROJECT_NUMBER", "123456789")
-	os.Setenv("POOL_ID", "test-pool")
-	os.Setenv("PROVIDER_ID", "test-provider")
+	require.NoError(b, os.Setenv("PROJECT_NUMBER", "123456789"))
+	require.NoError(b, os.Setenv("POOL_ID", "test-pool"))
+	require.NoError(b, os.Setenv("PROVIDER_ID", "test-provider"))
 	defer func() {
-		os.Unsetenv("PROJECT_NUMBER")
-		os.Unsetenv("POOL_ID")
-		os.Unsetenv("PROVIDER_ID")
+		require.NoError(b, os.Unsetenv("PROJECT_NUMBER"))
+		require.NoError(b, os.Unsetenv("POOL_ID"))
+		require.NoError(b, os.Unsetenv("PROVIDER_ID"))
 	}()
 
 	// Create test objects

--- a/test-multi-container-pod.yaml
+++ b/test-multi-container-pod.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: multi-container-test-pod
+  namespace: default
+  annotations:
+    workload-identity.io/inject-container-names: "app,sidecar"
+spec:
+  serviceAccountName: default
+  containers:
+  - name: app
+    image: nginx:1.21
+    ports:
+    - containerPort: 80
+  - name: sidecar
+    image: busybox:1.35
+    command: ["sleep", "3600"]
+  - name: logging
+    image: fluent/fluent-bit:2.0
+    command: ["sleep", "3600"]
+  - name: monitoring
+    image: prom/prometheus:v2.40.0
+    command: ["sleep", "3600"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: all-containers-test-pod
+  namespace: default
+spec:
+  serviceAccountName: default
+  containers:
+  - name: app
+    image: nginx:1.21
+    ports:
+    - containerPort: 80
+  - name: cache
+    image: redis:7-alpine
+  - name: db
+    image: postgres:15-alpine
+    env:
+    - name: POSTGRES_DB
+      value: testdb
+    - name: POSTGRES_USER
+      value: testuser
+    - name: POSTGRES_PASSWORD
+      value: testpass
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: init-containers-test-pod
+  namespace: default
+  annotations:
+    workload-identity.io/inject-container-names: "init-secrets,app"
+spec:
+  serviceAccountName: default
+  initContainers:
+  - name: init-secrets
+    image: vault:1.12
+    command: ["vault", "kv", "get", "secret/app-config"]
+  - name: init-local-setup
+    image: busybox:1.35
+    command: ["sh", "-c", "echo 'Local setup - no GCP access needed'"]
+  containers:
+  - name: app
+    image: nginx:1.21
+    ports:
+    - containerPort: 80
+  - name: monitoring
+    image: prom/prometheus:v2.40.0
+    ports:
+    - containerPort: 9090


### PR DESCRIPTION
## Summary

Adds support for selective WIF injection into specific containers and init containers using the `workload-identity.io/inject-container-names` annotation, similar to the OpenTelemetry operator's multi-container instrumentation pattern.

### Key Features

- **Selective Container Targeting**: Use `workload-identity.io/inject-container-names: "app,sidecar"` to inject WIF only into specified containers
- **Init Container Support**: Full support for init containers alongside regular containers  
- **Shared Volumes**: Volumes created once at pod level for efficiency
- **Backward Compatible**: Default behavior (no annotation) injects into all containers
- **Enhanced Observability**: Logs include container type (init vs regular) for better debugging

### Usage Examples

```yaml
# Target specific containers
metadata:
  annotations:
    workload-identity.io/inject-container-names: "app,init-secrets"
spec:
  initContainers:
  - name: init-secrets    # Gets WIF injection
    image: vault:1.12
  - name: init-local      # No WIF injection  
    image: busybox
  containers:
  - name: app            # Gets WIF injection
    image: nginx
  - name: sidecar        # No WIF injection
    image: busybox
```

```yaml
# Default behavior - all containers get WIF
# (no annotation needed)
```

### Real-World Use Cases

- Init containers pulling secrets from GCP Secret Manager
- Database migration containers needing Cloud SQL access
- Configuration containers downloading from GCS buckets
- Selective injection in complex multi-container workloads

### Implementation Details

- **Architecture**: Refactored injection logic into `injectIntoContainer()` helper for code reuse
- **Safety**: Same conflict detection applies to both init and regular containers  
- **Performance**: Single volume creation with targeted mount injection
- **Metrics**: Enhanced Prometheus metrics with container type labels

### Additional Fix

Also corrects kubebuilder webhook marker to remove `UPDATE` verb, matching the previous manifest fix that prevented mutation of immutable pod fields during updates.

## Test Plan

- [x] All existing tests pass
- [x] New comprehensive test coverage for multi-container scenarios
- [x] Init container specific test cases
- [x] Edge case handling (whitespace, empty annotations, non-existent containers)
- [x] Linting and formatting passes
- [x] Backward compatibility verified

### Test Coverage Added

- Multi-container injection (all vs selective)
- Init container targeting and mixed init/regular targeting  
- Annotation parsing with whitespace handling
- Edge cases (empty annotations, non-existent containers)
- Helper function unit tests (`parseTargetContainerNames`, `shouldInjectIntoContainer`)