### PR TITLE
fix: create servicemonitor

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -15,18 +15,18 @@ namePrefix: webhook-
 #    someName: someValue
 
 resources:
-#- ../crd
-- ../rbac
-- ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-- ../webhook
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-- ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
-# [METRICS] Expose the controller manager metrics service.
-- metrics_service.yaml
+  #- ../crd
+  - ../rbac
+  - ../manager
+  # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+  # crd/kustomization.yaml
+  - ../webhook
+  # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+  - ../certmanager
+  # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+  - ../prometheus
+  # [METRICS] Expose the controller manager metrics service.
+  - metrics_service.yaml
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
 # Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
@@ -35,106 +35,106 @@ resources:
 
 # Uncomment the patches line if you enable Metrics
 patches:
-# [METRICS] The following patch will enable the metrics endpoint using HTTPS and the port :8443.
-# More info: https://book.kubebuilder.io/reference/metrics
-- path: manager_metrics_patch.yaml
-  target:
-    kind: Deployment
-# [WIF] Add WIF configuration from environment variables
-# Add this patch to inject your WIF provider configuration:
-# - path: manager_wif_config_patch.yaml
-#   target:
-#     kind: Deployment
-# [E2E] Set image pull policy to IfNotPresent for Kind clusters
-- path: manager_image_pull_policy_patch.yaml
-  target:
-    kind: Deployment
+  # [METRICS] The following patch will enable the metrics endpoint using HTTPS and the port :8443.
+  # More info: https://book.kubebuilder.io/reference/metrics
+  - path: manager_metrics_patch.yaml
+    target:
+      kind: Deployment
+  # [WIF] Add WIF configuration from environment variables
+  # Add this patch to inject your WIF provider configuration:
+  # - path: manager_wif_config_patch.yaml
+  #   target:
+  #     kind: Deployment
+  # [E2E] Set image pull policy to IfNotPresent for Kind clusters
+  - path: manager_image_pull_policy_patch.yaml
+    target:
+      kind: Deployment
 
-# Uncomment the patches line if you enable Metrics and CertManager
-# [METRICS-WITH-CERTS] To enable metrics protected with certManager, uncomment the following line.
-# This patch will protect the metrics with certManager self-signed certs.
-#- path: cert_metrics_manager_patch.yaml
-#  target:
-#    kind: Deployment
+  # Uncomment the patches line if you enable Metrics and CertManager
+  # [METRICS-WITH-CERTS] To enable metrics protected with certManager, uncomment the following line.
+  # This patch will protect the metrics with certManager self-signed certs.
+  #- path: cert_metrics_manager_patch.yaml
+  #  target:
+  #    kind: Deployment
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-- path: manager_webhook_patch.yaml
-  target:
-    kind: Deployment
-- path: webhook_namespace_selector_patch.yaml
-  target:
-    kind: MutatingWebhookConfiguration
+  # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+  # crd/kustomization.yaml
+  - path: manager_webhook_patch.yaml
+    target:
+      kind: Deployment
+  - path: webhook_namespace_selector_patch.yaml
+    target:
+      kind: MutatingWebhookConfiguration
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations
 replacements:
-- source: # Uncomment the following block if you have any webhook
-    kind: Service
-    version: v1
-    name: webhook-service
-    fieldPath: .metadata.name # Name of the service
-  targets:
-    - select:
-        kind: Certificate
-        group: cert-manager.io
-        version: v1
-        name: serving-cert
-      fieldPaths:
-        - .spec.dnsNames.0
-        - .spec.dnsNames.1
-      options:
-        delimiter: '.'
-        index: 0
-        create: true
-- source:
-    kind: Service
-    version: v1
-    name: webhook-service
-    fieldPath: .metadata.namespace # Namespace of the service
-  targets:
-    - select:
-        kind: Certificate
-        group: cert-manager.io
-        version: v1
-        name: serving-cert
-      fieldPaths:
-        - .spec.dnsNames.0
-        - .spec.dnsNames.1
-      options:
-        delimiter: '.'
-        index: 1
-        create: true
-- source: # Uncomment the following block if you have a DefaultingWebhook (--defaulting )
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert
-    fieldPath: .metadata.namespace # Namespace of the certificate CR
-  targets:
-    - select:
-        kind: MutatingWebhookConfiguration
-      fieldPaths:
-        - .metadata.annotations.[cert-manager.io/inject-ca-from]
-      options:
-        delimiter: '/'
-        index: 0
-        create: true
-- source:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert
-    fieldPath: .metadata.name
-  targets:
-    - select:
-        kind: MutatingWebhookConfiguration
-      fieldPaths:
-        - .metadata.annotations.[cert-manager.io/inject-ca-from]
-      options:
-        delimiter: '/'
-        index: 1
-        create: true
+  - source: # Uncomment the following block if you have any webhook
+      kind: Service
+      version: v1
+      name: webhook-service
+      fieldPath: .metadata.name # Name of the service
+    targets:
+      - select:
+          kind: Certificate
+          group: cert-manager.io
+          version: v1
+          name: serving-cert
+        fieldPaths:
+          - .spec.dnsNames.0
+          - .spec.dnsNames.1
+        options:
+          delimiter: "."
+          index: 0
+          create: true
+  - source:
+      kind: Service
+      version: v1
+      name: webhook-service
+      fieldPath: .metadata.namespace # Namespace of the service
+    targets:
+      - select:
+          kind: Certificate
+          group: cert-manager.io
+          version: v1
+          name: serving-cert
+        fieldPaths:
+          - .spec.dnsNames.0
+          - .spec.dnsNames.1
+        options:
+          delimiter: "."
+          index: 1
+          create: true
+  - source: # Uncomment the following block if you have a DefaultingWebhook (--defaulting )
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+      name: serving-cert
+      fieldPath: .metadata.namespace # Namespace of the certificate CR
+    targets:
+      - select:
+          kind: MutatingWebhookConfiguration
+        fieldPaths:
+          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+        options:
+          delimiter: "/"
+          index: 0
+          create: true
+  - source:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+      name: serving-cert
+      fieldPath: .metadata.name
+    targets:
+      - select:
+          kind: MutatingWebhookConfiguration
+        fieldPaths:
+          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+        options:
+          delimiter: "/"
+          index: 1
+          create: true
 # - source: # Uncomment the following block to enable certificates for metrics
 #     kind: Service
 #     version: v1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable webhook, cert-manager, metrics patches, and CA injection in the default kustomization.
> 
> - **Kustomize config (`config/default/kustomization.yaml`)**:
>   - Enable resources: `../rbac`, `../manager`, `../webhook`, `../certmanager`, and `metrics_service.yaml` (keep `../crd` and `../network-policy` commented).
>   - Add patches: `manager_metrics_patch.yaml`, `manager_image_pull_policy_patch.yaml`, `manager_webhook_patch.yaml`, and `webhook_namespace_selector_patch.yaml` targeting `Deployment` and `MutatingWebhookConfiguration`.
>   - Enable cert-manager CA injection replacements: populate webhook `Certificate` DNS names from `Service`, and inject CA into `MutatingWebhookConfiguration` annotations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 960886a0a7077f0c559a4ce4976a9ef61119ec90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->