### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,4 +1,6 @@
 name: commitlint
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/groq/k8s-wif-webhook/security/code-scanning/1](https://github.com/groq/k8s-wif-webhook/security/code-scanning/1)

To fix the problem, a `permissions` block should be added to the workflow (or specifically to the `commitlint` job) in `.github/workflows/commitlint.yaml`. For commit linting, the action may only require `contents: read` to access commits, but if it makes comments on pull requests or provides status reports, it may also require `pull-requests: write`. However, the safest default is to use `contents: read` and only allow further permissions if necessary. In this case, begin by adding:

```yaml
permissions:
  contents: read
```
at the root level (just below `name`), or to the specific job if only needed there. If in future the action fails due to insufficient permissions, expand as needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a top-level `permissions: contents: read` to the `commitlint` workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a11f6197ff1309bd981e30d8d9547abed479cffe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->