### PR TITLE
feat(controllers)!: add ServiceAccount and Namespace controllers for WIF ConfigMap reconciliation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,6 +37,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/groq/k8s-wif-webhook/internal/controller"
 	"github.com/groq/k8s-wif-webhook/internal/version"
 	webhookv1 "github.com/groq/k8s-wif-webhook/internal/webhook/v1"
 	// +kubebuilder:scaffold:imports
@@ -200,6 +201,24 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	// Setup Namespace controller for direct identity ConfigMap management
+	if err = (&controller.NamespaceReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Namespace")
+		os.Exit(1)
+	}
+
+	// Setup ServiceAccount controller for impersonation ConfigMap reconciliation
+	if err = (&controller.ServiceAccountReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "ServiceAccount")
 		os.Exit(1)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -206,8 +206,9 @@ func main() {
 
 	// Setup Namespace controller for direct identity ConfigMap management
 	if err = (&controller.NamespaceReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("wif-namespace-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Namespace")
 		os.Exit(1)
@@ -215,8 +216,9 @@ func main() {
 
 	// Setup ServiceAccount controller for impersonation ConfigMap reconciliation
 	if err = (&controller.ServiceAccountReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("wif-serviceaccount-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ServiceAccount")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,6 +10,7 @@ rules:
   - configmaps
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/internal/controller/namespace_controller.go
+++ b/internal/controller/namespace_controller.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/groq/k8s-wif-webhook/internal/wif"
+)
+
+const (
+	directIdentityConfigMapName = "wif-credentials-direct"
+)
+
+var (
+	// directConfigMapOperations tracks direct identity ConfigMap operations during reconciliation
+	// This provides finer granularity than the built-in controller_runtime_reconcile_total metric
+	directConfigMapOperations = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wif_direct_configmap_operations_total",
+			Help: "Total number of direct identity ConfigMap operations",
+		},
+		[]string{"operation"}, // create, update, noop
+	)
+)
+
+func init() {
+	// Note: controller-runtime automatically provides:
+	// - controller_runtime_reconcile_total{controller="Namespace",result="success|error|requeue"}
+	// - controller_runtime_reconcile_errors_total{controller="Namespace"}
+	// - controller_runtime_reconcile_time_seconds{controller="Namespace"}
+	metrics.Registry.MustRegister(directConfigMapOperations)
+}
+
+// NamespaceReconciler reconciles Namespace objects and ensures direct identity ConfigMaps exist
+type NamespaceReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// SetupWithManager sets up the controller with the Manager
+func (r *NamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Namespace{}).
+		// Note: Cannot use Owns() here - Namespaces cannot own resources within themselves
+		// ConfigMaps will be cleaned up automatically when the namespace is deleted
+		Complete(r)
+}
+
+// Reconcile ensures the direct identity ConfigMap exists in each namespace
+func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+
+	// Fetch the Namespace
+	namespace := &corev1.Namespace{}
+	if err := r.Get(ctx, req.NamespacedName, namespace); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Namespace deleted - ConfigMap will be cleaned up automatically
+			log.V(1).Info("Namespace not found, likely deleted", "name", req.Name)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Skip terminating namespaces
+	if namespace.Status.Phase == corev1.NamespaceTerminating {
+		log.V(1).Info("Skipping terminating namespace", "namespace", namespace.Name)
+		return ctrl.Result{}, nil
+	}
+
+	// Skip namespaces that have explicitly opted out of WIF injection
+	// This prevents credential access even via manual ConfigMap mounting (security requirement)
+	if r.isWIFInjectionDisabled(namespace) {
+		log.V(1).Info("Skipping namespace with WIF injection disabled", "namespace", namespace.Name)
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("Reconciling direct identity ConfigMap for namespace", "namespace", namespace.Name)
+
+	// Reconcile the direct identity ConfigMap
+	if err := r.reconcileDirectConfigMap(ctx, namespace); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// isWIFInjectionDisabled checks if WIF injection is disabled at the namespace level
+// This matches the webhook's opt-out behavior to prevent credential access
+func (r *NamespaceReconciler) isWIFInjectionDisabled(namespace *corev1.Namespace) bool {
+	if namespace.Labels == nil {
+		return false
+	}
+
+	// Check namespace-level opt-out label (matches webhook behavior)
+	if inject, exists := namespace.Labels["workload-identity.io/injection"]; exists && inject == "disabled" {
+		return true
+	}
+
+	return false
+}
+
+// reconcileDirectConfigMap ensures the direct identity ConfigMap exists and is up-to-date
+func (r *NamespaceReconciler) reconcileDirectConfigMap(ctx context.Context, namespace *corev1.Namespace) error {
+	log := log.FromContext(ctx)
+
+	configMapKey := types.NamespacedName{
+		Name:      directIdentityConfigMapName,
+		Namespace: namespace.Name,
+	}
+
+	// Check if ConfigMap exists
+	existingCM := &corev1.ConfigMap{}
+	err := r.Get(ctx, configMapKey, existingCM)
+
+	// Generate expected ConfigMap
+	desiredCM := r.buildDirectConfigMap(namespace)
+
+	if apierrors.IsNotFound(err) {
+		// ConfigMap doesn't exist - create it
+		log.Info("Creating direct identity ConfigMap",
+			"configMap", directIdentityConfigMapName,
+			"namespace", namespace.Name)
+
+		if err := r.Create(ctx, desiredCM); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				// Race condition - another reconciliation created it
+				log.V(1).Info("ConfigMap already exists (race condition)", "configMap", directIdentityConfigMapName)
+				directConfigMapOperations.WithLabelValues("noop").Inc()
+				return nil
+			}
+			return fmt.Errorf("failed to create ConfigMap %s/%s: %w", namespace.Name, directIdentityConfigMapName, err)
+		}
+
+		directConfigMapOperations.WithLabelValues("create").Inc()
+		log.Info("Successfully created direct identity ConfigMap",
+			"configMap", directIdentityConfigMapName,
+			"namespace", namespace.Name)
+		return nil
+	}
+
+	if err != nil {
+		// Some other error occurred
+		return fmt.Errorf("failed to get ConfigMap %s/%s: %w", namespace.Name, directIdentityConfigMapName, err)
+	}
+
+	// ConfigMap exists - check if it needs updating
+	if r.configMapNeedsUpdate(existingCM, desiredCM) {
+		log.Info("Updating direct identity ConfigMap",
+			"configMap", directIdentityConfigMapName,
+			"namespace", namespace.Name)
+
+		// Update the ConfigMap
+		existingCM.Data = desiredCM.Data
+		existingCM.Labels = desiredCM.Labels
+
+		if err := r.Update(ctx, existingCM); err != nil {
+			return fmt.Errorf("failed to update ConfigMap %s/%s: %w", namespace.Name, directIdentityConfigMapName, err)
+		}
+
+		directConfigMapOperations.WithLabelValues("update").Inc()
+		log.Info("Successfully updated direct identity ConfigMap",
+			"configMap", directIdentityConfigMapName,
+			"namespace", namespace.Name)
+		return nil
+	}
+
+	// ConfigMap is up-to-date
+	log.V(1).Info("ConfigMap is up-to-date, no changes needed",
+		"configMap", directIdentityConfigMapName,
+		"namespace", namespace.Name)
+	directConfigMapOperations.WithLabelValues("noop").Inc()
+	return nil
+}
+
+// buildDirectConfigMap constructs the desired direct identity ConfigMap for the namespace
+func (r *NamespaceReconciler) buildDirectConfigMap(namespace *corev1.Namespace) *corev1.ConfigMap {
+	// Direct identity configuration
+	config := &wif.WIFConfig{
+		UseDirectIdentity:    true,
+		CredentialsConfigMap: directIdentityConfigMapName,
+	}
+
+	credentialsData := wif.GenerateCredentialsConfig(config)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      directIdentityConfigMapName,
+			Namespace: namespace.Name,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "k8s-native-wif-webhook",
+				"workload-identity.io/type":    "direct",
+			},
+		},
+		Data: map[string]string{
+			"credentials.json": credentialsData,
+		},
+	}
+
+	// Note: No owner reference - ConfigMap is shared across all pods in namespace
+	// It will be cleaned up when the namespace is deleted
+
+	return cm
+}
+
+// configMapNeedsUpdate determines if the existing ConfigMap needs to be updated
+func (r *NamespaceReconciler) configMapNeedsUpdate(existing, desired *corev1.ConfigMap) bool {
+	// Check credentials data
+	if existing.Data == nil || existing.Data["credentials.json"] != desired.Data["credentials.json"] {
+		return true
+	}
+
+	// Check labels
+	if existing.Labels == nil {
+		return true
+	}
+	if existing.Labels["app.kubernetes.io/managed-by"] != desired.Labels["app.kubernetes.io/managed-by"] {
+		return true
+	}
+	if existing.Labels["workload-identity.io/type"] != desired.Labels["workload-identity.io/type"] {
+		return true
+	}
+
+	return false
+}

--- a/internal/controller/namespace_controller_test.go
+++ b/internal/controller/namespace_controller_test.go
@@ -1,0 +1,442 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/groq/k8s-wif-webhook/internal/wif"
+)
+
+func TestNamespaceReconciler_Reconcile(t *testing.T) {
+	require.NoError(t, os.Setenv("WORKLOAD_IDENTITY_PROVIDER", "projects/123456789/locations/global/workloadIdentityPools/test-pool/providers/test-provider"))
+	defer os.Unsetenv("WORKLOAD_IDENTITY_PROVIDER")
+
+	s := runtime.NewScheme()
+	require.NoError(t, scheme.AddToScheme(s))
+
+	t.Run("creates direct identity ConfigMap for new namespace", func(t *testing.T) {
+		ctx := context.Background()
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-namespace",
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceActive,
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(s).WithObjects(ns).Build()
+
+		reconciler := &NamespaceReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name: ns.Name,
+			},
+		}
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Verify ConfigMap was created
+		cm := &corev1.ConfigMap{}
+		cmKey := types.NamespacedName{
+			Name:      "wif-credentials-direct",
+			Namespace: "test-namespace",
+		}
+		require.NoError(t, client.Get(ctx, cmKey, cm))
+
+		// Verify ConfigMap contents
+		assert.Equal(t, "k8s-native-wif-webhook", cm.Labels["app.kubernetes.io/managed-by"])
+		assert.Equal(t, "direct", cm.Labels["workload-identity.io/type"])
+		assert.Contains(t, cm.Data["credentials.json"], "external_account")
+		assert.Contains(t, cm.Data["credentials.json"], "projects/123456789")
+
+		// Verify no owner reference (shared resource)
+		assert.Len(t, cm.OwnerReferences, 0)
+	})
+
+	t.Run("updates ConfigMap when WORKLOAD_IDENTITY_PROVIDER changes", func(t *testing.T) {
+		ctx := context.Background()
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-namespace",
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceActive,
+			},
+		}
+
+		// Create existing ConfigMap with old provider
+		oldProvider := "projects/old/locations/global/workloadIdentityPools/old-pool/providers/old-provider"
+		os.Setenv("WORKLOAD_IDENTITY_PROVIDER", oldProvider)
+		oldConfig := &wif.WIFConfig{
+			UseDirectIdentity:    true,
+			CredentialsConfigMap: "wif-credentials-direct",
+		}
+		oldCredentials := wif.GenerateCredentialsConfig(oldConfig)
+
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "wif-credentials-direct",
+				Namespace: "test-namespace",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "k8s-native-wif-webhook",
+					"workload-identity.io/type":    "direct",
+				},
+			},
+			Data: map[string]string{
+				"credentials.json": oldCredentials,
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, existingCM).Build()
+
+		// Change provider (simulates webhook pod restart with new env var)
+		newProvider := "projects/123456789/locations/global/workloadIdentityPools/test-pool/providers/test-provider"
+		os.Setenv("WORKLOAD_IDENTITY_PROVIDER", newProvider)
+
+		reconciler := &NamespaceReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name: ns.Name,
+			},
+		}
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Verify ConfigMap was updated
+		cm := &corev1.ConfigMap{}
+		cmKey := types.NamespacedName{
+			Name:      "wif-credentials-direct",
+			Namespace: "test-namespace",
+		}
+		require.NoError(t, client.Get(ctx, cmKey, cm))
+
+		// Verify ConfigMap contains new provider
+		assert.Contains(t, cm.Data["credentials.json"], newProvider)
+		assert.NotContains(t, cm.Data["credentials.json"], oldProvider)
+	})
+
+	t.Run("self-heals ConfigMap when data is corrupted", func(t *testing.T) {
+		ctx := context.Background()
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-namespace",
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceActive,
+			},
+		}
+
+		// ConfigMap with corrupted data
+		corruptedCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "wif-credentials-direct",
+				Namespace: "test-namespace",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "k8s-native-wif-webhook",
+					"workload-identity.io/type":    "direct",
+				},
+			},
+			Data: map[string]string{
+				"credentials.json": `{"corrupted": "data"}`,
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, corruptedCM).Build()
+
+		reconciler := &NamespaceReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name: ns.Name,
+			},
+		}
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Verify ConfigMap was healed
+		cm := &corev1.ConfigMap{}
+		cmKey := types.NamespacedName{
+			Name:      "wif-credentials-direct",
+			Namespace: "test-namespace",
+		}
+		require.NoError(t, client.Get(ctx, cmKey, cm))
+
+		// Verify ConfigMap has correct structure
+		assert.Contains(t, cm.Data["credentials.json"], "external_account")
+		assert.Contains(t, cm.Data["credentials.json"], "audience")
+		assert.NotContains(t, cm.Data["credentials.json"], `"corrupted"`)
+	})
+
+	t.Run("self-heals ConfigMap when labels are missing", func(t *testing.T) {
+		ctx := context.Background()
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-namespace",
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceActive,
+			},
+		}
+
+		config := &wif.WIFConfig{
+			UseDirectIdentity:    true,
+			CredentialsConfigMap: "wif-credentials-direct",
+		}
+
+		// ConfigMap with missing labels
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "wif-credentials-direct",
+				Namespace: "test-namespace",
+				Labels:    nil, // Missing labels
+			},
+			Data: map[string]string{
+				"credentials.json": wif.GenerateCredentialsConfig(config),
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, existingCM).Build()
+
+		reconciler := &NamespaceReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name: ns.Name,
+			},
+		}
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Verify labels were restored
+		cm := &corev1.ConfigMap{}
+		cmKey := types.NamespacedName{
+			Name:      "wif-credentials-direct",
+			Namespace: "test-namespace",
+		}
+		require.NoError(t, client.Get(ctx, cmKey, cm))
+
+		assert.Equal(t, "k8s-native-wif-webhook", cm.Labels["app.kubernetes.io/managed-by"])
+		assert.Equal(t, "direct", cm.Labels["workload-identity.io/type"])
+	})
+
+	t.Run("skips terminating namespace", func(t *testing.T) {
+		ctx := context.Background()
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "terminating-namespace",
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceTerminating,
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(s).WithObjects(ns).Build()
+
+		reconciler := &NamespaceReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name: ns.Name,
+			},
+		}
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Verify no ConfigMap was created
+		cm := &corev1.ConfigMap{}
+		cmKey := types.NamespacedName{
+			Name:      "wif-credentials-direct",
+			Namespace: "terminating-namespace",
+		}
+		err = client.Get(ctx, cmKey, cm)
+		assert.Error(t, err, "ConfigMap should not exist")
+	})
+
+	t.Run("handles namespace deletion gracefully", func(t *testing.T) {
+		ctx := context.Background()
+
+		client := fake.NewClientBuilder().WithScheme(s).Build()
+
+		reconciler := &NamespaceReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name: "deleted-namespace",
+			},
+		}
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+	})
+
+	t.Run("skips namespace with opt-out label", func(t *testing.T) {
+		ctx := context.Background()
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "opted-out-namespace",
+				Labels: map[string]string{
+					"workload-identity.io/injection": "disabled",
+				},
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceActive,
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(s).WithObjects(ns).Build()
+
+		reconciler := &NamespaceReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name: ns.Name,
+			},
+		}
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Verify ConfigMap was NOT created (security requirement)
+		cm := &corev1.ConfigMap{}
+		cmKey := types.NamespacedName{
+			Name:      "wif-credentials-direct",
+			Namespace: "opted-out-namespace",
+		}
+		err = client.Get(ctx, cmKey, cm)
+		assert.Error(t, err, "ConfigMap should not exist in opted-out namespace")
+	})
+
+	t.Run("is idempotent when ConfigMap is up-to-date", func(t *testing.T) {
+		ctx := context.Background()
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-namespace",
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceActive,
+			},
+		}
+
+		config := &wif.WIFConfig{
+			UseDirectIdentity:    true,
+			CredentialsConfigMap: "wif-credentials-direct",
+		}
+
+		// ConfigMap already up-to-date
+		upToDateCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "wif-credentials-direct",
+				Namespace: "test-namespace",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "k8s-native-wif-webhook",
+					"workload-identity.io/type":    "direct",
+				},
+			},
+			Data: map[string]string{
+				"credentials.json": wif.GenerateCredentialsConfig(config),
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, upToDateCM).Build()
+
+		reconciler := &NamespaceReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name: ns.Name,
+			},
+		}
+
+		// First reconciliation
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Second reconciliation should be no-op
+		result, err = reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Verify ConfigMap unchanged
+		cm := &corev1.ConfigMap{}
+		cmKey := types.NamespacedName{
+			Name:      "wif-credentials-direct",
+			Namespace: "test-namespace",
+		}
+		require.NoError(t, client.Get(ctx, cmKey, cm))
+		assert.Equal(t, wif.GenerateCredentialsConfig(config), cm.Data["credentials.json"])
+	})
+}

--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -1,0 +1,302 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/groq/k8s-wif-webhook/internal/wif"
+)
+
+var (
+	// configMapReconcileOperations tracks ConfigMap operations during reconciliation
+	// This provides finer granularity than the built-in controller_runtime_reconcile_total metric
+	configMapReconcileOperations = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wif_configmap_reconcile_operations_total",
+			Help: "Total number of ConfigMap reconciliation operations",
+		},
+		[]string{"operation"}, // create, update, noop, delete
+	)
+)
+
+func init() {
+	// Note: controller-runtime automatically provides:
+	// - controller_runtime_reconcile_total{controller="ServiceAccount",result="success|error|requeue"}
+	// - controller_runtime_reconcile_errors_total{controller="ServiceAccount"}
+	// - controller_runtime_reconcile_time_seconds{controller="ServiceAccount"}
+	metrics.Registry.MustRegister(configMapReconcileOperations)
+}
+
+// ServiceAccountReconciler reconciles ServiceAccount objects with WIF annotations
+type ServiceAccountReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// SetupWithManager sets up the controller with the Manager
+func (r *ServiceAccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ServiceAccount{}).
+		Owns(&corev1.ConfigMap{}).
+		Complete(r)
+}
+
+// Reconcile handles ServiceAccount changes and manages impersonation ConfigMaps
+func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+
+	// Fetch the ServiceAccount
+	sa := &corev1.ServiceAccount{}
+	if err := r.Get(ctx, req.NamespacedName, sa); err != nil {
+		if apierrors.IsNotFound(err) {
+			// ServiceAccount deleted - ConfigMap will be cleaned up via owner reference
+			log.V(1).Info("ServiceAccount not found, likely deleted", "name", req.Name, "namespace", req.Namespace)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Check if namespace has opted out of WIF injection
+	// This prevents credential access even via manual ConfigMap mounting (security requirement)
+	namespace := &corev1.Namespace{}
+	if err := r.Get(ctx, types.NamespacedName{Name: sa.Namespace}, namespace); err != nil {
+		log.Error(err, "Failed to get namespace for opt-out check", "namespace", sa.Namespace)
+		return ctrl.Result{}, err
+	}
+
+	if r.isWIFInjectionDisabled(namespace) {
+		log.V(1).Info("Skipping ServiceAccount in namespace with WIF injection disabled",
+			"serviceAccount", sa.Name, "namespace", sa.Namespace)
+		return ctrl.Result{}, nil
+	}
+
+	// Extract WIF configuration
+	config := wif.ExtractWIFConfig(sa)
+
+	// Only reconcile impersonation ConfigMaps (direct identity is handled by namespace controller)
+	if config.UseDirectIdentity {
+		log.V(1).Info("ServiceAccount uses direct identity, no ConfigMap to reconcile",
+			"serviceAccount", sa.Name, "namespace", sa.Namespace)
+		return ctrl.Result{}, nil
+	}
+
+	// Check if ServiceAccount has impersonation annotation
+	gcpSA, hasAnnotation := sa.Annotations["iam.gke.io/gcp-service-account"]
+	if !hasAnnotation {
+		// This shouldn't happen if ExtractWIFConfig works correctly, but double-check
+		log.V(1).Info("ServiceAccount missing impersonation annotation",
+			"serviceAccount", sa.Name, "namespace", sa.Namespace)
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("Reconciling impersonation ConfigMap for ServiceAccount",
+		"serviceAccount", sa.Name,
+		"namespace", sa.Namespace,
+		"gcpServiceAccount", gcpSA,
+		"configMap", config.CredentialsConfigMap)
+
+	// Reconcile the ConfigMap
+	if err := r.reconcileConfigMap(ctx, sa, config); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// isWIFInjectionDisabled checks if WIF injection is disabled at the namespace level
+// This matches the webhook's opt-out behavior to prevent credential access
+func (r *ServiceAccountReconciler) isWIFInjectionDisabled(namespace *corev1.Namespace) bool {
+	if namespace.Labels == nil {
+		return false
+	}
+
+	// Check namespace-level opt-out label (matches webhook behavior)
+	if inject, exists := namespace.Labels["workload-identity.io/injection"]; exists && inject == "disabled" {
+		return true
+	}
+
+	return false
+}
+
+// reconcileConfigMap ensures the impersonation ConfigMap exists and is up-to-date
+func (r *ServiceAccountReconciler) reconcileConfigMap(ctx context.Context, sa *corev1.ServiceAccount, config *wif.WIFConfig) error {
+	log := log.FromContext(ctx)
+
+	configMapKey := types.NamespacedName{
+		Name:      config.CredentialsConfigMap,
+		Namespace: sa.Namespace,
+	}
+
+	// Check if ConfigMap exists
+	existingCM := &corev1.ConfigMap{}
+	err := r.Get(ctx, configMapKey, existingCM)
+
+	// Generate expected ConfigMap
+	desiredCM := r.buildConfigMap(sa, config)
+
+	if apierrors.IsNotFound(err) {
+		// ConfigMap doesn't exist - create it
+		log.Info("Creating impersonation ConfigMap",
+			"configMap", config.CredentialsConfigMap,
+			"namespace", sa.Namespace,
+			"gcpServiceAccount", config.GoogleServiceAccount)
+
+		if err := r.Create(ctx, desiredCM); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				// Race condition - another reconciliation created it
+				log.V(1).Info("ConfigMap already exists (race condition)", "configMap", config.CredentialsConfigMap)
+				configMapReconcileOperations.WithLabelValues("noop").Inc()
+				return nil
+			}
+			return fmt.Errorf("failed to create ConfigMap %s/%s: %w", sa.Namespace, config.CredentialsConfigMap, err)
+		}
+
+		configMapReconcileOperations.WithLabelValues("create").Inc()
+		log.Info("Successfully created impersonation ConfigMap",
+			"configMap", config.CredentialsConfigMap,
+			"namespace", sa.Namespace)
+		return nil
+	}
+
+	if err != nil {
+		// Some other error occurred
+		return fmt.Errorf("failed to get ConfigMap %s/%s: %w", sa.Namespace, config.CredentialsConfigMap, err)
+	}
+
+	// ConfigMap exists - check if it needs updating
+	if r.configMapNeedsUpdate(existingCM, desiredCM) {
+		log.Info("Updating impersonation ConfigMap",
+			"configMap", config.CredentialsConfigMap,
+			"namespace", sa.Namespace,
+			"gcpServiceAccount", config.GoogleServiceAccount)
+
+		// Update the ConfigMap
+		existingCM.Data = desiredCM.Data
+		existingCM.Labels = desiredCM.Labels
+		existingCM.OwnerReferences = desiredCM.OwnerReferences
+
+		if err := r.Update(ctx, existingCM); err != nil {
+			return fmt.Errorf("failed to update ConfigMap %s/%s: %w", sa.Namespace, config.CredentialsConfigMap, err)
+		}
+
+		configMapReconcileOperations.WithLabelValues("update").Inc()
+		log.Info("Successfully updated impersonation ConfigMap",
+			"configMap", config.CredentialsConfigMap,
+			"namespace", sa.Namespace)
+		return nil
+	}
+
+	// ConfigMap is up-to-date
+	log.V(1).Info("ConfigMap is up-to-date, no changes needed",
+		"configMap", config.CredentialsConfigMap,
+		"namespace", sa.Namespace)
+	configMapReconcileOperations.WithLabelValues("noop").Inc()
+	return nil
+}
+
+// buildConfigMap constructs the desired ConfigMap for the given ServiceAccount and WIF config
+func (r *ServiceAccountReconciler) buildConfigMap(sa *corev1.ServiceAccount, config *wif.WIFConfig) *corev1.ConfigMap {
+	credentialsData := wif.GenerateCredentialsConfig(config)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.CredentialsConfigMap,
+			Namespace: sa.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "k8s-native-wif-webhook",
+				"workload-identity.io/type":    wif.GetConfigMapType(config),
+			},
+		},
+		Data: map[string]string{
+			"credentials.json": credentialsData,
+		},
+	}
+
+	// Set ServiceAccount as owner for automatic cleanup
+	controller := true
+	cm.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+			Name:       sa.Name,
+			UID:        sa.UID,
+			Controller: &controller,
+		},
+	}
+
+	return cm
+}
+
+// configMapNeedsUpdate determines if the existing ConfigMap needs to be updated
+func (r *ServiceAccountReconciler) configMapNeedsUpdate(existing, desired *corev1.ConfigMap) bool {
+	// Check credentials data
+	if existing.Data == nil || existing.Data["credentials.json"] != desired.Data["credentials.json"] {
+		return true
+	}
+
+	// Check labels
+	if existing.Labels == nil {
+		return true
+	}
+	if existing.Labels["app.kubernetes.io/managed-by"] != desired.Labels["app.kubernetes.io/managed-by"] {
+		return true
+	}
+	if existing.Labels["workload-identity.io/type"] != desired.Labels["workload-identity.io/type"] {
+		return true
+	}
+
+	// Check owner references
+	if !controllerutil.HasControllerReference(existing) {
+		return true
+	}
+
+	// Compare owner reference (ServiceAccount UID might have changed)
+	if len(existing.OwnerReferences) != len(desired.OwnerReferences) {
+		return true
+	}
+
+	for i := range existing.OwnerReferences {
+		existingRef := existing.OwnerReferences[i]
+		desiredRef := desired.OwnerReferences[i]
+
+		if existingRef.UID != desiredRef.UID ||
+			existingRef.Name != desiredRef.Name ||
+			existingRef.Kind != desiredRef.Kind {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/controller/serviceaccount_controller_test.go
+++ b/internal/controller/serviceaccount_controller_test.go
@@ -1,0 +1,582 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/groq/k8s-wif-webhook/internal/wif"
+)
+
+func TestServiceAccountReconciler_Reconcile(t *testing.T) {
+	require.NoError(t, os.Setenv("WORKLOAD_IDENTITY_PROVIDER", "projects/123456789/locations/global/workloadIdentityPools/test-pool/providers/test-provider"))
+	defer os.Unsetenv("WORKLOAD_IDENTITY_PROVIDER")
+
+	s := runtime.NewScheme()
+	require.NoError(t, scheme.AddToScheme(s))
+
+	t.Run("creates ConfigMap for ServiceAccount with impersonation annotation", func(t *testing.T) {
+		ctx := context.Background()
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		}
+
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sa",
+				Namespace: "default",
+				UID:       types.UID("test-uid-123"),
+				Annotations: map[string]string{
+					"iam.gke.io/gcp-service-account": "test@project.iam.gserviceaccount.com",
+				},
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, sa).Build()
+
+		reconciler := &ServiceAccountReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      sa.Name,
+				Namespace: sa.Namespace,
+			},
+		}
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Verify ConfigMap was created
+		cm := &corev1.ConfigMap{}
+		cmKey := types.NamespacedName{
+			Name:      "wif-credentials-impersonation-test-sa",
+			Namespace: "default",
+		}
+		require.NoError(t, client.Get(ctx, cmKey, cm))
+
+		// Verify ConfigMap contents
+		assert.Equal(t, "k8s-native-wif-webhook", cm.Labels["app.kubernetes.io/managed-by"])
+		assert.Equal(t, "impersonation", cm.Labels["workload-identity.io/type"])
+		assert.Contains(t, cm.Data["credentials.json"], "test@project.iam.gserviceaccount.com")
+
+		// Verify owner reference
+		require.Len(t, cm.OwnerReferences, 1)
+		assert.Equal(t, "ServiceAccount", cm.OwnerReferences[0].Kind)
+		assert.Equal(t, sa.Name, cm.OwnerReferences[0].Name)
+		assert.Equal(t, sa.UID, cm.OwnerReferences[0].UID)
+		assert.True(t, *cm.OwnerReferences[0].Controller)
+	})
+
+	t.Run("updates ConfigMap when ServiceAccount annotation changes", func(t *testing.T) {
+		ctx := context.Background()
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		}
+
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sa",
+				Namespace: "default",
+				UID:       types.UID("test-uid-456"),
+				Annotations: map[string]string{
+					"iam.gke.io/gcp-service-account": "test@project.iam.gserviceaccount.com",
+				},
+			},
+		}
+
+		// Create existing ConfigMap with old GCP SA
+		oldConfig := &wif.WIFConfig{
+			UseDirectIdentity:    false,
+			GoogleServiceAccount: "old@project.iam.gserviceaccount.com",
+			CredentialsConfigMap: "wif-credentials-impersonation-test-sa",
+		}
+
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "wif-credentials-impersonation-test-sa",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "k8s-native-wif-webhook",
+					"workload-identity.io/type":    "impersonation",
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "ServiceAccount",
+						Name:       sa.Name,
+						UID:        sa.UID,
+						Controller: &[]bool{true}[0],
+					},
+				},
+			},
+			Data: map[string]string{
+				"credentials.json": wif.GenerateCredentialsConfig(oldConfig),
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, sa, existingCM).Build()
+
+		reconciler := &ServiceAccountReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      sa.Name,
+				Namespace: sa.Namespace,
+			},
+		}
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Verify ConfigMap was updated
+		cm := &corev1.ConfigMap{}
+		cmKey := types.NamespacedName{
+			Name:      "wif-credentials-impersonation-test-sa",
+			Namespace: "default",
+		}
+		require.NoError(t, client.Get(ctx, cmKey, cm))
+
+		// Verify ConfigMap contains new GCP SA
+		assert.Contains(t, cm.Data["credentials.json"], "test@project.iam.gserviceaccount.com")
+		assert.NotContains(t, cm.Data["credentials.json"], "old@project.iam.gserviceaccount.com")
+	})
+
+	t.Run("updates ConfigMap when ServiceAccount UID changes (recreated)", func(t *testing.T) {
+		ctx := context.Background()
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		}
+
+		newUID := types.UID("new-uid-789")
+		oldUID := types.UID("old-uid-123")
+
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sa",
+				Namespace: "default",
+				UID:       newUID,
+				Annotations: map[string]string{
+					"iam.gke.io/gcp-service-account": "test@project.iam.gserviceaccount.com",
+				},
+			},
+		}
+
+		// ConfigMap with old UID in owner reference
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "wif-credentials-impersonation-test-sa",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "k8s-native-wif-webhook",
+					"workload-identity.io/type":    "impersonation",
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "ServiceAccount",
+						Name:       sa.Name,
+						UID:        oldUID, // Old UID
+						Controller: &[]bool{true}[0],
+					},
+				},
+			},
+			Data: map[string]string{
+				"credentials.json": wif.GenerateCredentialsConfig(&wif.WIFConfig{
+					UseDirectIdentity:    false,
+					GoogleServiceAccount: "test@project.iam.gserviceaccount.com",
+					CredentialsConfigMap: "wif-credentials-impersonation-test-sa",
+				}),
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, sa, existingCM).Build()
+
+		reconciler := &ServiceAccountReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      sa.Name,
+				Namespace: sa.Namespace,
+			},
+		}
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Verify ConfigMap owner reference was updated to new UID
+		cm := &corev1.ConfigMap{}
+		cmKey := types.NamespacedName{
+			Name:      "wif-credentials-impersonation-test-sa",
+			Namespace: "default",
+		}
+		require.NoError(t, client.Get(ctx, cmKey, cm))
+
+		require.Len(t, cm.OwnerReferences, 1)
+		assert.Equal(t, newUID, cm.OwnerReferences[0].UID)
+	})
+
+	t.Run("skips ServiceAccount without impersonation annotation", func(t *testing.T) {
+		ctx := context.Background()
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		}
+
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sa",
+				Namespace: "default",
+				UID:       types.UID("test-uid-999"),
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, sa).Build()
+
+		reconciler := &ServiceAccountReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      sa.Name,
+				Namespace: sa.Namespace,
+			},
+		}
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Verify no ConfigMap was created
+		cm := &corev1.ConfigMap{}
+		cmKey := types.NamespacedName{
+			Name:      "wif-credentials-impersonation-test-sa",
+			Namespace: "default",
+		}
+		err = client.Get(ctx, cmKey, cm)
+		assert.Error(t, err, "ConfigMap should not exist")
+	})
+
+	t.Run("handles ServiceAccount deletion gracefully", func(t *testing.T) {
+		ctx := context.Background()
+
+		client := fake.NewClientBuilder().WithScheme(s).Build()
+
+		reconciler := &ServiceAccountReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "deleted-sa",
+				Namespace: "default",
+			},
+		}
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+	})
+
+	t.Run("skips ServiceAccount in opted-out namespace", func(t *testing.T) {
+		ctx := context.Background()
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "opted-out-namespace",
+				Labels: map[string]string{
+					"workload-identity.io/injection": "disabled",
+				},
+			},
+		}
+
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sa",
+				Namespace: "opted-out-namespace",
+				UID:       types.UID("test-uid-opted-out"),
+				Annotations: map[string]string{
+					"iam.gke.io/gcp-service-account": "test@project.iam.gserviceaccount.com",
+				},
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, sa).Build()
+
+		reconciler := &ServiceAccountReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      sa.Name,
+				Namespace: sa.Namespace,
+			},
+		}
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Verify ConfigMap was NOT created (security requirement)
+		cm := &corev1.ConfigMap{}
+		cmKey := types.NamespacedName{
+			Name:      "wif-credentials-impersonation-test-sa",
+			Namespace: "opted-out-namespace",
+		}
+		err = client.Get(ctx, cmKey, cm)
+		assert.Error(t, err, "ConfigMap should not exist in opted-out namespace")
+	})
+
+	t.Run("is idempotent when ConfigMap is up-to-date", func(t *testing.T) {
+		ctx := context.Background()
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		}
+
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sa",
+				Namespace: "default",
+				UID:       types.UID("test-uid-idempotent"),
+				Annotations: map[string]string{
+					"iam.gke.io/gcp-service-account": "test@project.iam.gserviceaccount.com",
+				},
+			},
+		}
+
+		config := wif.ExtractWIFConfig(sa)
+
+		// ConfigMap already up-to-date
+		upToDateCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.CredentialsConfigMap,
+				Namespace: "default",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "k8s-native-wif-webhook",
+					"workload-identity.io/type":    "impersonation",
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "ServiceAccount",
+						Name:       sa.Name,
+						UID:        sa.UID,
+						Controller: &[]bool{true}[0],
+					},
+				},
+			},
+			Data: map[string]string{
+				"credentials.json": wif.GenerateCredentialsConfig(config),
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, sa, upToDateCM).Build()
+
+		reconciler := &ServiceAccountReconciler{
+			Client: client,
+			Scheme: s,
+		}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      sa.Name,
+				Namespace: sa.Namespace,
+			},
+		}
+
+		// First reconciliation
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Second reconciliation should be no-op
+		result, err = reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		// Verify ConfigMap unchanged
+		cm := &corev1.ConfigMap{}
+		cmKey := types.NamespacedName{
+			Name:      config.CredentialsConfigMap,
+			Namespace: "default",
+		}
+		require.NoError(t, client.Get(ctx, cmKey, cm))
+		assert.Equal(t, wif.GenerateCredentialsConfig(config), cm.Data["credentials.json"])
+	})
+}
+
+func TestServiceAccountReconciler_configMapNeedsUpdate(t *testing.T) {
+	reconciler := &ServiceAccountReconciler{}
+
+	t.Run("returns false when ConfigMaps are identical", func(t *testing.T) {
+		existing := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "k8s-native-wif-webhook",
+					"workload-identity.io/type":    "impersonation",
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "ServiceAccount",
+						Name:       "test-sa",
+						UID:        types.UID("test-uid"),
+						Controller: &[]bool{true}[0],
+					},
+				},
+			},
+			Data: map[string]string{
+				"credentials.json": "test-credentials",
+			},
+		}
+
+		desired := existing.DeepCopy()
+
+		assert.False(t, reconciler.configMapNeedsUpdate(existing, desired))
+	})
+
+	t.Run("returns true when credentials data differs", func(t *testing.T) {
+		existing := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "k8s-native-wif-webhook",
+					"workload-identity.io/type":    "impersonation",
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "ServiceAccount",
+						Name:       "test-sa",
+						UID:        types.UID("test-uid"),
+						Controller: &[]bool{true}[0],
+					},
+				},
+			},
+			Data: map[string]string{
+				"credentials.json": "old-credentials",
+			},
+		}
+
+		desired := existing.DeepCopy()
+		desired.Data["credentials.json"] = "new-credentials"
+
+		assert.True(t, reconciler.configMapNeedsUpdate(existing, desired))
+	})
+
+	t.Run("returns true when owner reference UID differs", func(t *testing.T) {
+		existing := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "k8s-native-wif-webhook",
+					"workload-identity.io/type":    "impersonation",
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "ServiceAccount",
+						Name:       "test-sa",
+						UID:        types.UID("old-uid"),
+						Controller: &[]bool{true}[0],
+					},
+				},
+			},
+			Data: map[string]string{
+				"credentials.json": "test-credentials",
+			},
+		}
+
+		desired := existing.DeepCopy()
+		desired.OwnerReferences[0].UID = types.UID("new-uid")
+
+		assert.True(t, reconciler.configMapNeedsUpdate(existing, desired))
+	})
+
+	t.Run("returns true when labels are missing", func(t *testing.T) {
+		existing := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: nil,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "ServiceAccount",
+						Name:       "test-sa",
+						UID:        types.UID("test-uid"),
+						Controller: &[]bool{true}[0],
+					},
+				},
+			},
+			Data: map[string]string{
+				"credentials.json": "test-credentials",
+			},
+		}
+
+		desired := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "k8s-native-wif-webhook",
+					"workload-identity.io/type":    "impersonation",
+				},
+				OwnerReferences: existing.OwnerReferences,
+			},
+			Data: existing.Data,
+		}
+
+		assert.True(t, reconciler.configMapNeedsUpdate(existing, desired))
+	})
+}

--- a/internal/wif/config.go
+++ b/internal/wif/config.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wif
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// WIFConfig holds workload identity federation configuration
+type WIFConfig struct {
+	UseDirectIdentity    bool
+	GoogleServiceAccount string
+	CredentialsConfigMap string
+}
+
+// ExtractWIFConfig extracts WIF configuration from a ServiceAccount
+func ExtractWIFConfig(sa *corev1.ServiceAccount) *WIFConfig {
+	// Check for GKE-style service account impersonation annotation (takes precedence)
+	if sa.Annotations != nil {
+		if gcpSA, ok := sa.Annotations["iam.gke.io/gcp-service-account"]; ok {
+			// Use k8s ServiceAccount name for ConfigMap to enable owner references
+			configMapName := fmt.Sprintf("wif-credentials-impersonation-%s", sa.Name)
+			return &WIFConfig{
+				UseDirectIdentity:    false,
+				GoogleServiceAccount: gcpSA,
+				CredentialsConfigMap: configMapName,
+			}
+		}
+	}
+
+	// Default: Direct federated identity (opt-out behavior)
+	// Users can disable via namespace or pod labels
+	return &WIFConfig{
+		UseDirectIdentity:    true,
+		CredentialsConfigMap: "wif-credentials-direct",
+	}
+}
+
+// GetWorkloadIdentityProvider returns the full workload identity provider path from environment
+func GetWorkloadIdentityProvider() string {
+	if provider := os.Getenv("WORKLOAD_IDENTITY_PROVIDER"); provider != "" {
+		return provider
+	}
+	return "${WORKLOAD_IDENTITY_PROVIDER}" // Fallback to template processing
+}
+
+// GenerateCredentialsConfig generates the credentials JSON configuration for WIF
+func GenerateCredentialsConfig(config *WIFConfig) string {
+	// Get the full provider path and format as audience
+	providerPath := GetWorkloadIdentityProvider()
+	audience := "//iam.googleapis.com/" + providerPath
+
+	if config.UseDirectIdentity {
+		// Direct federated identity configuration
+		credConfig := map[string]interface{}{
+			"type":               "external_account",
+			"audience":           audience,
+			"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+			"token_url":          "https://sts.googleapis.com/v1/token",
+			"credential_source": map[string]interface{}{
+				"file": "/var/run/service-account/token",
+			},
+		}
+		data, _ := json.MarshalIndent(credConfig, "", "  ")
+		return string(data)
+	} else {
+		// Service account impersonation configuration
+		credConfig := map[string]interface{}{
+			"universe_domain":    "googleapis.com",
+			"type":               "external_account",
+			"audience":           audience,
+			"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+			"token_url":          "https://sts.googleapis.com/v1/token",
+			"credential_source": map[string]interface{}{
+				"file": "/var/run/service-account/token",
+				"format": map[string]interface{}{
+					"type": "text",
+				},
+			},
+			"service_account_impersonation_url": fmt.Sprintf("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken", config.GoogleServiceAccount),
+		}
+		data, _ := json.MarshalIndent(credConfig, "", "  ")
+		return string(data)
+	}
+}
+
+// GetConfigMapType returns the type label for the ConfigMap
+func GetConfigMapType(config *WIFConfig) string {
+	if config.UseDirectIdentity {
+		return "direct"
+	}
+	return "impersonation"
+}

--- a/internal/wif/config_test.go
+++ b/internal/wif/config_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wif
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExtractWIFConfig(t *testing.T) {
+	t.Run("returns impersonation config when annotation is present", func(t *testing.T) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sa",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"iam.gke.io/gcp-service-account": "test@project.iam.gserviceaccount.com",
+				},
+			},
+		}
+
+		config := ExtractWIFConfig(sa)
+
+		assert.False(t, config.UseDirectIdentity)
+		assert.Equal(t, "test@project.iam.gserviceaccount.com", config.GoogleServiceAccount)
+		assert.Equal(t, "wif-credentials-impersonation-test-sa", config.CredentialsConfigMap)
+	})
+
+	t.Run("returns direct identity config when annotation is absent", func(t *testing.T) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sa",
+				Namespace: "default",
+			},
+		}
+
+		config := ExtractWIFConfig(sa)
+
+		assert.True(t, config.UseDirectIdentity)
+		assert.Empty(t, config.GoogleServiceAccount)
+		assert.Equal(t, "wif-credentials-direct", config.CredentialsConfigMap)
+	})
+
+	t.Run("returns direct identity config when annotations map is nil", func(t *testing.T) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-sa",
+				Namespace:   "default",
+				Annotations: nil,
+			},
+		}
+
+		config := ExtractWIFConfig(sa)
+
+		assert.True(t, config.UseDirectIdentity)
+		assert.Equal(t, "wif-credentials-direct", config.CredentialsConfigMap)
+	})
+
+	t.Run("uses ServiceAccount name in ConfigMap name for impersonation", func(t *testing.T) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-service-account",
+				Namespace: "production",
+				Annotations: map[string]string{
+					"iam.gke.io/gcp-service-account": "prod@project.iam.gserviceaccount.com",
+				},
+			},
+		}
+
+		config := ExtractWIFConfig(sa)
+
+		assert.Equal(t, "wif-credentials-impersonation-my-service-account", config.CredentialsConfigMap)
+	})
+}
+
+func TestGetWorkloadIdentityProvider(t *testing.T) {
+	t.Run("returns environment variable when set", func(t *testing.T) {
+		expected := "projects/123/locations/global/workloadIdentityPools/pool/providers/provider"
+		os.Setenv("WORKLOAD_IDENTITY_PROVIDER", expected)
+		defer os.Unsetenv("WORKLOAD_IDENTITY_PROVIDER")
+
+		result := GetWorkloadIdentityProvider()
+
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("returns template placeholder when environment variable is not set", func(t *testing.T) {
+		os.Unsetenv("WORKLOAD_IDENTITY_PROVIDER")
+
+		result := GetWorkloadIdentityProvider()
+
+		assert.Equal(t, "${WORKLOAD_IDENTITY_PROVIDER}", result)
+	})
+}
+
+func TestGenerateCredentialsConfig(t *testing.T) {
+	providerPath := "projects/123456789/locations/global/workloadIdentityPools/test-pool/providers/test-provider"
+	os.Setenv("WORKLOAD_IDENTITY_PROVIDER", providerPath)
+	defer os.Unsetenv("WORKLOAD_IDENTITY_PROVIDER")
+
+	t.Run("generates direct identity configuration", func(t *testing.T) {
+		config := &WIFConfig{
+			UseDirectIdentity:    true,
+			CredentialsConfigMap: "wif-credentials-direct",
+		}
+
+		result := GenerateCredentialsConfig(config)
+
+		// Parse JSON to verify structure
+		var credConfig map[string]interface{}
+		err := json.Unmarshal([]byte(result), &credConfig)
+		require.NoError(t, err)
+
+		assert.Equal(t, "external_account", credConfig["type"])
+		assert.Equal(t, "//iam.googleapis.com/"+providerPath, credConfig["audience"])
+		assert.Equal(t, "urn:ietf:params:oauth:token-type:jwt", credConfig["subject_token_type"])
+		assert.Equal(t, "https://sts.googleapis.com/v1/token", credConfig["token_url"])
+
+		credSource, ok := credConfig["credential_source"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "/var/run/service-account/token", credSource["file"])
+
+		// Should not have impersonation URL
+		_, hasImpersonation := credConfig["service_account_impersonation_url"]
+		assert.False(t, hasImpersonation)
+	})
+
+	t.Run("generates impersonation configuration", func(t *testing.T) {
+		config := &WIFConfig{
+			UseDirectIdentity:    false,
+			GoogleServiceAccount: "test@project.iam.gserviceaccount.com",
+			CredentialsConfigMap: "wif-credentials-impersonation-test",
+		}
+
+		result := GenerateCredentialsConfig(config)
+
+		// Parse JSON to verify structure
+		var credConfig map[string]interface{}
+		err := json.Unmarshal([]byte(result), &credConfig)
+		require.NoError(t, err)
+
+		assert.Equal(t, "external_account", credConfig["type"])
+		assert.Equal(t, "googleapis.com", credConfig["universe_domain"])
+		assert.Equal(t, "//iam.googleapis.com/"+providerPath, credConfig["audience"])
+		assert.Equal(t, "urn:ietf:params:oauth:token-type:jwt", credConfig["subject_token_type"])
+		assert.Equal(t, "https://sts.googleapis.com/v1/token", credConfig["token_url"])
+
+		credSource, ok := credConfig["credential_source"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "/var/run/service-account/token", credSource["file"])
+
+		format, ok := credSource["format"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "text", format["type"])
+
+		// Should have impersonation URL
+		impersonationURL, ok := credConfig["service_account_impersonation_url"].(string)
+		require.True(t, ok)
+		assert.Contains(t, impersonationURL, "test@project.iam.gserviceaccount.com")
+		assert.Contains(t, impersonationURL, "generateAccessToken")
+	})
+
+	t.Run("generates valid JSON for direct identity", func(t *testing.T) {
+		config := &WIFConfig{
+			UseDirectIdentity:    true,
+			CredentialsConfigMap: "wif-credentials-direct",
+		}
+
+		result := GenerateCredentialsConfig(config)
+
+		// Verify it's valid JSON
+		var jsonData map[string]interface{}
+		err := json.Unmarshal([]byte(result), &jsonData)
+		assert.NoError(t, err)
+	})
+
+	t.Run("generates valid JSON for impersonation", func(t *testing.T) {
+		config := &WIFConfig{
+			UseDirectIdentity:    false,
+			GoogleServiceAccount: "service@project.iam.gserviceaccount.com",
+			CredentialsConfigMap: "wif-credentials-impersonation-test",
+		}
+
+		result := GenerateCredentialsConfig(config)
+
+		// Verify it's valid JSON
+		var jsonData map[string]interface{}
+		err := json.Unmarshal([]byte(result), &jsonData)
+		assert.NoError(t, err)
+	})
+}
+
+func TestGetConfigMapType(t *testing.T) {
+	t.Run("returns 'direct' for direct identity", func(t *testing.T) {
+		config := &WIFConfig{
+			UseDirectIdentity: true,
+		}
+
+		result := GetConfigMapType(config)
+
+		assert.Equal(t, "direct", result)
+	})
+
+	t.Run("returns 'impersonation' for impersonation mode", func(t *testing.T) {
+		config := &WIFConfig{
+			UseDirectIdentity: false,
+		}
+
+		result := GetConfigMapType(config)
+
+		assert.Equal(t, "impersonation", result)
+	})
+}


### PR DESCRIPTION
## Summary

Add controllers to handle WIF ConfigMap lifecycle management while maintaining atomic creation in the webhook for zero-downtime pod admission.

## Architecture: Hybrid Approach

### 🚀 Webhook (Fast Path)
- **Atomic ConfigMap creation** on first pod admission (proven, optimized)
- **No race condition** - ConfigMap exists before pod starts  
- **Zero user impact** - transparent, foolproof
- Delegates all updates to controllers

### 🔄 ServiceAccountReconciler
- Watches ServiceAccounts with `iam.gke.io/gcp-service-account` annotation
- Reconciles impersonation ConfigMaps on annotation changes **(CREL-91)**
- Sets owner references for automatic cleanup
- Self-healing on drift

### 🌐 NamespaceReconciler  
- Watches all Namespaces
- Manages `wif-credentials-direct` ConfigMaps
- Self-heals on `WORKLOAD_IDENTITY_PROVIDER` changes
- Ensures direct identity ConfigMaps always exist

## Key Features

✅ **No race conditions** - atomic creation during admission  
✅ **Transparent to users** - proven webhook logic preserved  
✅ **Handles annotation changes** - controllers reconcile updates (CREL-91)  
✅ **Self-healing** - controllers fix drift and env var changes  
✅ **Security maintained** - respects opt-out labels everywhere  
✅ **Best of both worlds** - webhook fast path + controller reconciliation  

## Metrics

- `wif_webhook_configmap_operations_total` (webhook creates)
- `wif_configmap_reconcile_operations_total` (SA controller)
- `wif_direct_configmap_operations_total` (namespace controller)
- Built-in `controller_runtime_reconcile_total` and `controller_runtime_reconcile_errors_total`

## Testing

- 100% coverage in shared `internal/wif` package
- Comprehensive controller tests (create, update, delete, opt-out)
- Webhook tests for atomic creation and idempotency
- 77.2% coverage in controllers, 76.4% in webhook

## Breaking Changes

⚠️ **BREAKING CHANGE**: ConfigMap updates now handled by controllers instead of webhook. Requires running both ServiceAccount and Namespace controllers.

Existing deployments will continue to work as:
- Webhook creates ConfigMaps on-demand (as before)
- Controllers reconcile existing ConfigMaps on startup
- No manual intervention required

## References

Fixes: CREL-91

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ServiceAccount and Namespace reconcilers to manage WIF credential ConfigMaps, refactors webhook to create-only, introduces shared WIF config package, updates metrics/RBAC/manager wiring, and adds comprehensive tests.
> 
> - **Controllers**:
>   - `ServiceAccountReconciler`: reconciles impersonation `ConfigMap`s per `ServiceAccount` (owner refs, drift/self-heal, opt-out respected).
>   - `NamespaceReconciler`: ensures `wif-credentials-direct` per `Namespace` (opt-out respected, self-heal on provider/env changes).
> - **Webhook**:
>   - Now performs atomic `ConfigMap` creation only; updates delegated to controllers.
>   - Uses shared `internal/wif` utilities; adds `wif_webhook_configmap_operations_total` metric.
>   - RBAC narrowed to `configmaps` create (get/list/watch/create).
> - **Shared WIF package** (`internal/wif`):
>   - Adds `WIFConfig`, `ExtractWIFConfig`, `GenerateCredentialsConfig`, `GetWorkloadIdentityProvider`, `GetConfigMapType`.
> - **Manager/RBAC**:
>   - Registers new controllers in `cmd/main.go`.
>   - Updates `ClusterRole` to include `configmaps` delete and watch `namespaces`/`serviceaccounts`.
> - **Metrics**:
>   - Adds `wif_configmap_reconcile_operations_total` (SA controller) and `wif_direct_configmap_operations_total` (Namespace controller).
> - **Tests**:
>   - Extensive unit tests for controllers, webhook creation path, and shared WIF utilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f6424ab7a6f79bfa245f545cb192fb0038d3edf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->